### PR TITLE
Added python test file

### DIFF
--- a/.github/workflows/python_tests.yml
+++ b/.github/workflows/python_tests.yml
@@ -1,0 +1,30 @@
+name: Run Python Tests with No Flight Controller
+
+on:
+  push:
+    branches: [ main ]
+  pull_request:
+    branches: [ main ]
+
+jobs:
+  build:
+
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v3
+
+    - name: Set up Python 3.11
+      uses: actions/setup-python@v4
+      with:
+        python-version: "3.11"
+
+    - name: Install dependencies
+      run: |
+        python -m pip install --upgrade pip
+        python -m pip install pytest
+
+    - name: Test with pytest
+      working-directory: ./radio
+      run: |
+        python run_tests.py -nfc

--- a/.github/workflows/python_tests.yml
+++ b/.github/workflows/python_tests.yml
@@ -20,9 +20,11 @@ jobs:
         python-version: "3.11"
 
     - name: Install dependencies
+      working-directory: ./radio
       run: |
         python -m pip install --upgrade pip
         python -m pip install pytest
+        python -m pip install -r requirements.txt
 
     - name: Test with pytest
       working-directory: ./radio


### PR DESCRIPTION
Added python test test file workflow to run the `run_tests.py` file in `radio` using the `-nfc` flag as github actions can't pretend to have a flight controller (maybe fix this in the future?)