### PR TITLE
fix

### DIFF
--- a/gcs/src/components/fla/graphConfigs.js
+++ b/gcs/src/components/fla/graphConfigs.js
@@ -104,7 +104,8 @@ export const fgcsOptions = {
       ...defaultOptions.scales.x,
       type: 'time',
       time: {
-        unit: 'second',
+        // removed to fix issue #342
+        //unit: 'second',
         displayFormats: {
           second: 'HH:mm:ss',
         },


### PR DESCRIPTION
issued cause by large time difference in log file, removed units from graph config to circumvent issue. Units are still display on the correct axis. Needs more thorough testing. 