### PR TITLE
Alpha 0.1.8/430 unpredictable follow drone behaviour

### DIFF
--- a/gcs/src/components/dashboard/map.jsx
+++ b/gcs/src/components/dashboard/map.jsx
@@ -62,6 +62,7 @@ export default function MapSection({
   heading,
   desiredBearing,
   missionItems,
+  onDragstart,
 }) {
   const [position, setPosition] = useState(null)
   const [firstCenteredToDrone, setFirstCenteredToDrone] = useState(false)
@@ -108,6 +109,7 @@ export default function MapSection({
             zoom: newViewState.viewState.zoom,
           })
         }
+        onDragStart={onDragstart}
       >
         {/* Show marker on map if the position is set */}
         {position !== null &&

--- a/gcs/src/dashboard.jsx
+++ b/gcs/src/dashboard.jsx
@@ -447,6 +447,7 @@ export default function Dashboard() {
         center: [lon, lat],
       })
     }
+    setFollowDrone(false)
   }
 
   return (

--- a/gcs/src/dashboard.jsx
+++ b/gcs/src/dashboard.jsx
@@ -775,7 +775,7 @@ export default function Dashboard() {
             icon={<IconGps />}
             value={`(${gpsData.lat !== undefined ? (gpsData.lat * 1e-7).toFixed(6) : 0}, ${
               gpsData.lon !== undefined ? (gpsData.lon * 1e-7).toFixed(6) : 0
-            })`}
+              })`}
             tooltip='GPS (lat, lon)'
           />
           <StatusSection
@@ -817,7 +817,18 @@ export default function Dashboard() {
             <ActionIcon
               disabled={!gpsData.lon && !gpsData.lat}
               onClick={() => {
-                setFollowDrone(!followDrone)
+                setFollowDrone(followDrone ? false : (() => {
+                  if (
+                    mapRef.current &&
+                    gpsData?.lon !== 0 &&
+                    gpsData?.lat !== 0
+                  ) {
+                    let lat = parseFloat(gpsData.lat * 1e-7)
+                    let lon = parseFloat(gpsData.lon * 1e-7)
+                    mapRef.current.setCenter({ lng: lon, lat: lat })
+                  }
+                  return true
+                })())
               }}
             >
               {followDrone ? <IconAnchorOff /> : <IconAnchor />}

--- a/gcs/src/dashboard.jsx
+++ b/gcs/src/dashboard.jsx
@@ -460,6 +460,9 @@ export default function Dashboard() {
             heading={gpsData.hdg ? gpsData.hdg / 100 : 0}
             desiredBearing={navControllerOutputData.nav_bearing}
             missionItems={missionItems}
+            onDragstart={() => {
+              setFollowDrone(false)
+            }}
           />
         </div>
 


### PR DESCRIPTION
Fixes #430 
When follow drone mode enabled, now immediately centers drone on map rather than wait for GPS data to arrive.
When user drags map, disable follow drone mode
When user centers on mission, disable follow drone mode