### PR TITLE
Alpha 0.1.8/505 support python 3.9

### DIFF
--- a/radio/app/controllers/gripperController.py
+++ b/radio/app/controllers/gripperController.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Optional
 
 import serial
 from app.customTypes import Response
@@ -51,12 +51,12 @@ class GripperController:
                 ),
             }
 
-    def getEnabled(self) -> bool | None:
+    def getEnabled(self) -> Optional[bool]:
         """
         Gets the enabled status of the gripper by checking the value of the GRIP_ENABLE param
 
         Returns:
-            bool | None
+            Optional[bool]
         """
         gripper_enabled_response = self.drone.paramsController.getSingleParam(
             param_name="GRIP_ENABLE"

--- a/radio/app/endpoints/params.py
+++ b/radio/app/endpoints/params.py
@@ -52,7 +52,7 @@ def refresh_params() -> None:
 
     droneStatus.drone.paramsController.getAllParams()
 
-    timeout = time.time() + 20 # 20 seconds from now yipee
+    timeout = time.time() + 20  # 20 seconds from now yipee
     last_index_sent = -1
 
     while droneStatus.drone and droneStatus.drone.paramsController.is_requesting_params:

--- a/radio/app/utils.py
+++ b/radio/app/utils.py
@@ -1,5 +1,5 @@
 import sys
-from typing import Any, List
+from typing import Any, List, Optional, Union
 
 from pymavlink import mavutil
 from serial.tools import list_ports
@@ -138,12 +138,12 @@ def droneConnectStatusCb(msg: Any) -> None:
     socketio.emit("drone_connect_status", {"message": msg})
 
 
-def notConnectedError(action: str | None = None) -> None:
+def notConnectedError(action: Optional[str] = None) -> None:
     """
     Send error to the socket indicating that drone connection must be established to complete this action
 
     Args:
-        action (str | None): The action the that requires drone connection. Default `None`.
+        action Optional[str]: The action the that requires drone connection. Default `None`.
     """
     socketio.emit(
         "connection_error",
@@ -153,13 +153,13 @@ def notConnectedError(action: str | None = None) -> None:
     )
 
 
-def missingParameterError(endpoint: str, params: str | list[str]) -> None:
+def missingParameterError(endpoint: str, params: Union[str, List[str]]) -> None:
     """ "
     Send error to the socket indicating that a request made to the server was missing required parameters
 
     Args
         endpoint (str): The endpoint that is missing a parameter
-        params (str | list[str]): The names of the parameter/s that are missing from the request
+        params Union[str, List[str]]: The names of the parameter/s that are missing from the request
     """
     socketio.emit(
         "drone_error",

--- a/radio/tests/helpers.py
+++ b/radio/tests/helpers.py
@@ -120,6 +120,7 @@ class NoAcknowledgementMessage:
         if droneStatus.drone is not None:
             droneStatus.drone.master.recv_match = self.old_recv
 
+
 class RecvMsgReturnsFalse:
     @staticmethod
     def recv_match_false(
@@ -136,6 +137,7 @@ class RecvMsgReturnsFalse:
         if droneStatus.drone is not None:
             droneStatus.drone.master.recv_match = self.old_recv
 
+
 class SetAircraftType:
     def __init__(self, aircraftType: int):
         self.aircraftType = aircraftType
@@ -148,6 +150,7 @@ class SetAircraftType:
     def __exit__(self, type, value, traceback) -> None:
         if droneStatus.drone is not None:
             droneStatus.drone.aircraft_type = self.old_aircraftType
+
 
 def send_and_recieve(endpoint: str, args: Optional[Union[dict, str]] = None) -> dict:
     """Sends a request to the socketio test client and returns the response

--- a/radio/tests/helpers.py
+++ b/radio/tests/helpers.py
@@ -1,4 +1,5 @@
 import pytest
+from typing import Optional, Union
 from serial.serialutil import SerialException
 
 from app import droneStatus, logger
@@ -148,14 +149,14 @@ class SetAircraftType:
         if droneStatus.drone is not None:
             droneStatus.drone.aircraft_type = self.old_aircraftType
 
-def send_and_recieve(endpoint: str, args: dict | None | str = None) -> dict:
+def send_and_recieve(endpoint: str, args: Optional[Union[dict, str]] = None) -> dict:
     """Sends a request to the socketio test client and returns the response
 
     Parameters
     ----------
     endpoint : str
         The endpoint to send the request to
-    args : dict | None, optional
+    args : Optional[Union[dict, str]], optional
         The arguments to pass to the endpoint, by default None
 
     Returns

--- a/radio/tests/test_comPorts.py
+++ b/radio/tests/test_comPorts.py
@@ -1,5 +1,6 @@
 import sys
 import pytest
+from typing import Union
 
 from serial.tools import list_ports
 from serial.tools.list_ports_common import ListPortInfo
@@ -10,7 +11,7 @@ from . import socketio_client
 from .conftest import setupDrone
 from .helpers import send_and_recieve
 
-VALID_DRONE_PORT: str | ListPortInfo
+VALID_DRONE_PORT: Union[str, ListPortInfo]
 
 
 @pytest.fixture(scope="module", autouse=True)

--- a/radio/tests/test_params.py
+++ b/radio/tests/test_params.py
@@ -1,4 +1,5 @@
 import pytest
+from typing import Optional, Union
 from flask_socketio.test_client import SocketIOTestClient
 
 from . import falcon_test
@@ -7,7 +8,7 @@ from typing import List, Any
 
 
 def send_and_receive_params(
-    client: SocketIOTestClient, endpoint: str, args: List[Any] | None | str = None
+    client: SocketIOTestClient, endpoint: str, args: Optional[Union[List[Any], str]] = None
 ) -> dict:
     """
     Sends a request to the socketio test client and awaits a response, returning the entire response (name and args)
@@ -15,7 +16,7 @@ def send_and_receive_params(
     Args:
         client: The socketio test client
         endpoint(str): The endpoint to send the request to
-        args(dict | None | str): The arguments to pass to the endpoint
+        args(Optional[Union[List[Any], str]]): The arguments to pass to the endpoint
 
     Returns:
          The data received from the client (name and arguments of the socket.emit)

--- a/radio/tests/test_params.py
+++ b/radio/tests/test_params.py
@@ -8,7 +8,9 @@ from typing import List, Any
 
 
 def send_and_receive_params(
-    client: SocketIOTestClient, endpoint: str, args: Optional[Union[List[Any], str]] = None
+    client: SocketIOTestClient,
+    endpoint: str,
+    args: Optional[Union[List[Any], str]] = None,
 ) -> dict:
     """
     Sends a request to the socketio test client and awaits a response, returning the entire response (name and args)


### PR DESCRIPTION
Removed all the | type hints and replaced them with the Optional / Union alternatives which are compatible with python 3.9
![image](https://github.com/user-attachments/assets/c2cec09c-4f23-46ba-9a3c-e4336f350d02)
