### PR TITLE
Revert "Bump electron from 26.6.10 to 37.1.0 in /gcs in the npm_and_yarn group across 1 directory"

### DIFF
--- a/gcs/package.json
+++ b/gcs/package.json
@@ -86,7 +86,7 @@
     "@vitejs/plugin-react": "^4.0.4",
     "@vitest/browser": "^2.0.5",
     "autoprefixer": "^10.4.16",
-    "electron": "^37.1.0",
+    "electron": "^26.1.0",
     "electron-builder": "^24.6.4",
     "eslint": "^8.48.0",
     "eslint-plugin-react-hooks": "^4.6.0",


### PR DESCRIPTION
Reverts Avis-Drone-Labs/FGCS#587