### PR TITLE
Alpha 0.1.10/641 spotlight commands for connection to drone isnt working

### DIFF
--- a/gcs/src/components/spotlight/commandHandler.js
+++ b/gcs/src/components/spotlight/commandHandler.js
@@ -49,12 +49,6 @@ export function Commands() {
   AddCommand("open_settings", () => {
     open()
   })
-  AddCommand("connect_to_drone", () => {
-    /* connect */
-  })
-  AddCommand("disconnect_from_drone", () => {
-    /* disconnect */
-  })
 
   // Register hotkeys
   useHotkeys([
@@ -83,6 +77,14 @@ export function AddCommand(id, command, shortcut = null, macShortcut = null) {
 
 export function RunCommand(id) {
   // Search for a command by id
+
+  var cmd = commands.find((entry) => entry.id == id);
+  if (cmd !== undefined) {
+    cmd.command();
+  } else {
+    console.log(`Couldn't find command ${id} to run`)
+  }
+
   try {
     commands.find((entry) => entry.id == id).command()
   } catch {

--- a/gcs/src/components/spotlight/commandHandler.js
+++ b/gcs/src/components/spotlight/commandHandler.js
@@ -72,6 +72,8 @@ export function AddCommand(id, command, shortcut = null, macShortcut = null) {
       shortcut: shortcut,
       macShortcut: macShortcut,
     })
+  } else{
+    console.log(`Attempting to add command that already exists: ${id}`)
   }
 }
 


### PR DESCRIPTION
Fixed, there were empty commands with identical names in commandHandler.js which meant the actual commands weren't being registered, added a console warning for when this happens