### PR TITLE
Removed CSS on indicator. 

### DIFF
--- a/gcs/src/components/dashboard/telemetrySection/indicator.jsx
+++ b/gcs/src/components/dashboard/telemetrySection/indicator.jsx
@@ -23,7 +23,7 @@ const box = {
   left: 0,
 
   // Stops dragging
-  "WebkitUserDrag": "none",
+  WebkitUserDrag: "none",
 }
 
 // Custom instrument styling for each indicator below


### PR DESCRIPTION
"WebkitUserDrag" is all that is necessary to make the change I wanted to make. No more errors appear in the console.