### PR TITLE
Add mavlink forwarding on successful reboot

### DIFF
--- a/gcs/src/redux/middleware/socketMiddleware.js
+++ b/gcs/src/redux/middleware/socketMiddleware.js
@@ -12,8 +12,6 @@ import {
   emitGetComPorts,
   emitIsConnectedToDrone,
   setComPorts,
-  emitStartForwarding,
-  selectIsForwarding,
   setConnected,
   setConnecting,
   setConnectionModal,
@@ -533,8 +531,6 @@ const socketMiddleware = (store) => {
             store.dispatch(setAutoPilotRebootModalOpen(false))
             showSuccessNotification(msg.message)
             store.dispatch(setRebootData({}))
-            const isForwarding = selectIsForwarding(store.getState())
-            if (isForwarding) store.dispatch(emitStartForwarding())
           }
         })
 

--- a/radio/app/endpoints/autopilot.py
+++ b/radio/app/endpoints/autopilot.py
@@ -16,8 +16,6 @@ def rebootAutopilot() -> None:
     if not droneStatus.drone:
         return
 
-    # TODO: Add forwarding address handling here too
-
     port = droneStatus.drone.port
     baud = droneStatus.drone.baud
     wireless = droneStatus.drone.wireless
@@ -25,6 +23,7 @@ def rebootAutopilot() -> None:
     droneDisconnectCb = droneStatus.drone.droneDisconnectCb
     droneConnectStatusCb = droneStatus.drone.droneConnectStatusCb
     linkDebugStatsCb = droneStatus.drone.linkDebugStatsCb
+    forwarding_address = droneStatus.drone.forwarding_address
 
     socketio.emit("disconnected_from_drone")
 
@@ -51,6 +50,7 @@ def rebootAutopilot() -> None:
             port,
             baud=baud,
             wireless=wireless,
+            forwarding_address=forwarding_address,
             droneErrorCb=droneErrorCb,
             droneDisconnectCb=droneDisconnectCb,
             droneConnectStatusCb=droneConnectStatusCb,


### PR DESCRIPTION
Passes the forwarding address to the new drone instance on reboot. Given this address, the init function then already handles the actual begin forwarding.