### PR TITLE
[EXAMPLE] Using signals instead of callbacks

### DIFF
--- a/radio/app/controllers/armController.py
+++ b/radio/app/controllers/armController.py
@@ -91,7 +91,7 @@ class ArmController:
             self.drone.error(str(e))
 
             ## Or you can have just have:                 (TODO: remove)
-            DroneError.send(str(e))
+            DroneError.send(self, msg=str(e))
 
             return {
                 "success": False,

--- a/radio/app/controllers/armController.py
+++ b/radio/app/controllers/armController.py
@@ -4,7 +4,7 @@ import time
 from threading import current_thread
 from typing import TYPE_CHECKING
 
-from app.signals import drone_error
+from app.signals import DroneError
 from app.customTypes import Response
 from app.utils import commandAccepted, sendingCommandLock
 from pymavlink import mavutil
@@ -90,8 +90,8 @@ class ArmController:
             self.drone.logger.error(e, exc_info=True)
             self.drone.error(str(e))
 
-            ## Or you can have:                 (TODO: remove)
-            drone_error.send(str(e))
+            ## Or you can have just have:                 (TODO: remove)
+            DroneError.send(str(e))
 
             return {
                 "success": False,

--- a/radio/app/controllers/armController.py
+++ b/radio/app/controllers/armController.py
@@ -4,6 +4,7 @@ import time
 from threading import current_thread
 from typing import TYPE_CHECKING
 
+from app.signals import drone_error
 from app.customTypes import Response
 from app.utils import commandAccepted, sendingCommandLock
 from pymavlink import mavutil
@@ -87,8 +88,11 @@ class ArmController:
 
         except Exception as e:
             self.drone.logger.error(e, exc_info=True)
-            if self.drone.droneErrorCb:
-                self.drone.droneErrorCb(str(e))
+            self.drone.error(str(e))
+
+            ## Or you can have:                 (TODO: remove)
+            drone_error.send(str(e))
+
             return {
                 "success": False,
                 "message": "Could not arm, serial exception",

--- a/radio/app/drone.py
+++ b/radio/app/drone.py
@@ -27,7 +27,7 @@ from app.controllers.rcController import RcController
 from app.controllers.serialPortsController import SerialPortsController
 from app.controllers.servoController import ServoController
 from app.customTypes import Number, Response, VehicleType
-from app.signals import drone_error
+from app.signals import DroneError, DroneConnectStatus
 from app.utils import (
     commandAccepted,
     decodeFlightSwVersion,
@@ -83,7 +83,6 @@ class Drone:
         forwarding_address: Optional[str] = None,
         droneErrorCb: Optional[Callable] = None,
         droneDisconnectCb: Optional[Callable] = None,
-        droneConnectStatusCb: Optional[Callable] = None,
         linkDebugStatsCb: Optional[Callable] = None,
         fetchingParameterCb: Optional[Callable] = None,
         connectionCancelEvent: Optional[Event] = None,
@@ -96,7 +95,6 @@ class Drone:
             baud (int, optional): The baud rate for the connection. Defaults to 57600.
             droneErrorCb (Optional[Callable], optional): Callback function for drone errors. Defaults to None.
             droneDisconnectCb (Optional[Callable], optional): Callback function for drone disconnection. Defaults to None.
-            droneConnectStatusCb (Optional[Callable], optional): Callback function for drone connection providing an update as the drone connects. Defaults to None.
             linkDebugStatsCb (Optional[Callable], optional): Callback function for link debug stats. Defaults to None.
             fetchingParameterCb (Optional[Callable], optional): Callback function for when parameters are being fetched. Defaults to None.
             connectionCancelEvent (Optional[Event], optional): Event to signal if the connection process should be cancelled. Defaults to None.
@@ -106,7 +104,6 @@ class Drone:
         self.logger = logger
         self.droneErrorCb = droneErrorCb
         self.droneDisconnectCb = droneDisconnectCb
-        self.droneConnectStatusCb = droneConnectStatusCb
         self.linkDebugStatsCb = linkDebugStatsCb
         self.fetchingParameterCb = fetchingParameterCb
         self.connection_cancel_event: Event = connectionCancelEvent or Event()
@@ -372,9 +369,6 @@ class Drone:
     def _emitConnectionStatus(
         self, message: str, progress: float, sub_message: str = ""
     ) -> None:
-        if not self.droneConnectStatusCb:
-            return
-
         progress = round(min(max(float(progress), 0.0), 100.0), 2)
         progress = max(progress, self._last_connect_progress)
         payload = {
@@ -387,7 +381,7 @@ class Drone:
             return
 
         try:
-            self.droneConnectStatusCb(payload)
+            DroneConnectStatus.send(payload)
         except Exception:
             self.logger.exception("Connection status callback failed")
             return
@@ -1264,7 +1258,7 @@ class Drone:
             return {"success": False, "message": "Not currently forwarding"}
 
     def error(self, msg: str) -> None:
-        drone_error.send(msg)
+        DroneError.send(msg)
 
     def close(self) -> None:
         """Close the connection to the drone."""

--- a/radio/app/drone.py
+++ b/radio/app/drone.py
@@ -381,7 +381,7 @@ class Drone:
             return
 
         try:
-            DroneConnectStatus.send(payload)
+            DroneConnectStatus.send(self, msg=payload)
         except Exception:
             self.logger.exception("Connection status callback failed")
             return
@@ -1258,7 +1258,7 @@ class Drone:
             return {"success": False, "message": "Not currently forwarding"}
 
     def error(self, msg: str) -> None:
-        DroneError.send(msg)
+        DroneError.send(self, msg=msg)
 
     def close(self) -> None:
         """Close the connection to the drone."""

--- a/radio/app/drone.py
+++ b/radio/app/drone.py
@@ -27,6 +27,7 @@ from app.controllers.rcController import RcController
 from app.controllers.serialPortsController import SerialPortsController
 from app.controllers.servoController import ServoController
 from app.customTypes import Number, Response, VehicleType
+from app.signals import drone_error
 from app.utils import (
     commandAccepted,
     decodeFlightSwVersion,
@@ -739,8 +740,7 @@ class Drone:
                 msg = self.master.recv_msg()
             except mavutil.mavlink.MAVError as e:
                 self.logger.error(e, exc_info=True)
-                if self.droneErrorCb:
-                    self.droneErrorCb(str(e))
+                self.error(str(e))
                 continue
             except AttributeError as e:
                 self.logger.error(e, exc_info=True)
@@ -755,8 +755,7 @@ class Drone:
             except Exception as e:
                 # Log any other unexpected exception
                 self.logger.error(e, exc_info=True)
-                if self.droneErrorCb:
-                    self.droneErrorCb(str(e))
+                self.error(str(e))
                 continue
 
             if msg is None:
@@ -1263,6 +1262,9 @@ class Drone:
             return {"success": True, "message": "Stopped forwarding"}
         else:
             return {"success": False, "message": "Not currently forwarding"}
+
+    def error(self, msg: str) -> None:
+        drone_error.send(msg)
 
     def close(self) -> None:
         """Close the connection to the drone."""

--- a/radio/app/endpoints/autopilot.py
+++ b/radio/app/endpoints/autopilot.py
@@ -20,7 +20,6 @@ def rebootAutopilot() -> None:
     baud = droneStatus.drone.baud
     droneErrorCb = droneStatus.drone.droneErrorCb
     droneDisconnectCb = droneStatus.drone.droneDisconnectCb
-    droneConnectStatusCb = droneStatus.drone.droneConnectStatusCb
     linkDebugStatsCb = droneStatus.drone.linkDebugStatsCb
     fetchingParameterCb = droneStatus.drone.fetchingParameterCb
     forwarding_address = droneStatus.drone.forwarding_address
@@ -54,7 +53,6 @@ def rebootAutopilot() -> None:
             forwarding_address=forwarding_address,
             droneErrorCb=droneErrorCb,
             droneDisconnectCb=droneDisconnectCb,
-            droneConnectStatusCb=droneConnectStatusCb,
             linkDebugStatsCb=linkDebugStatsCb,
             fetchingParameterCb=fetchingParameterCb,
         )

--- a/radio/app/endpoints/comPorts.py
+++ b/radio/app/endpoints/comPorts.py
@@ -10,7 +10,6 @@ import app.droneStatus as droneStatus
 from app import logger, socketio
 from app.drone import Drone
 from app.utils import (
-    droneConnectStatusCb,
     droneErrorCb,
     fetchingParameterCb,
     getComPortNames,
@@ -157,7 +156,6 @@ def connectToDrone(data: ConnectionDataType) -> None:
             forwarding_address=forwarding_address,
             droneErrorCb=droneErrorCb,
             droneDisconnectCb=disconnectFromDrone,
-            droneConnectStatusCb=droneConnectStatusCb,
             linkDebugStatsCb=sendLinkDebugStats,
             fetchingParameterCb=fetchingParameterCb,
             connectionCancelEvent=cancel_event,

--- a/radio/app/signals.py
+++ b/radio/app/signals.py
@@ -4,38 +4,44 @@ from . import socketio
 from typing import TypedDict, NotRequired
 from app.customTypes import Number
 
+import logging
+
+logger = logging.getLogger("fgcs")
+
 # Define signals
 DroneError = Signal()
 DroneConnectStatus = Signal()
 
 
 @DroneError.connect
-def droneErrorHandler(msg: str) -> None:
+def droneErrorHandler(sender, msg: str) -> None:
     """
     Send drone error to the socket
 
     Args:
         msg: The error message to send to the client
     """
+    logger.debug(f"dronErrorHandler called by: {sender} with msg: {msg}")
     socketio.emit("drone_error", {"message": msg})
 
     ## Optionally you can add return values
     ## That would be what the function would return to the caller
-    # return "Received"
+    # return {success: true}
 
 
-class ConnectionDataType(TypedDict):
+class DroneConnectionStatusDataType(TypedDict):
     message: str
     progress: Number
     sub_message: NotRequired[str]
 
 
 @DroneConnectStatus.connect
-def droneConnectStatusHandler(msg: ConnectionDataType) -> None:
+def droneConnectStatusHandler(sender, msg: DroneConnectionStatusDataType) -> None:
     """
     Send drone connect status updates to the socket
 
     Args:
         msg: The connect message to send to the client
     """
+    logger.debug(f"droneConnectStatusHandler called by: {sender} with msg: {msg}")
     socketio.emit("drone_connect_status", msg)

--- a/radio/app/signals.py
+++ b/radio/app/signals.py
@@ -1,13 +1,41 @@
 from blinker import Signal
 from . import socketio
 
-drone_error = Signal()
+from typing import TypedDict, NotRequired
+from app.customTypes import Number
+
+# Define signals
+DroneError = Signal()
+DroneConnectStatus = Signal()
 
 
-@drone_error.connect
-def drone_error_handler(msg: str):
+@DroneError.connect
+def droneErrorHandler(msg: str) -> None:
+    """
+    Send drone error to the socket
+
+    Args:
+        msg: The error message to send to the client
+    """
     socketio.emit("drone_error", {"message": msg})
 
     ## Optionally you can add return values
     ## That would be what the function would return to the caller
     # return "Received"
+
+
+class ConnectionDataType(TypedDict):
+    message: str
+    progress: Number
+    sub_message: NotRequired[str]
+
+
+@DroneConnectStatus.connect
+def droneConnectStatusHandler(msg: ConnectionDataType) -> None:
+    """
+    Send drone connect status updates to the socket
+
+    Args:
+        msg: The connect message to send to the client
+    """
+    socketio.emit("drone_connect_status", msg)

--- a/radio/app/signals.py
+++ b/radio/app/signals.py
@@ -1,0 +1,13 @@
+from blinker import Signal
+from . import socketio
+
+drone_error = Signal()
+
+
+@drone_error.connect
+def drone_error_handler(msg: str):
+    socketio.emit("drone_error", {"message": msg})
+
+    ## Optionally you can add return values
+    ## That would be what the function would return to the caller
+    # return "Received"

--- a/radio/app/utils.py
+++ b/radio/app/utils.py
@@ -4,9 +4,8 @@ from typing import Any, List, Optional, Union
 
 from pymavlink import mavutil
 from serial.tools import list_ports
-from typing_extensions import NotRequired, TypedDict
 
-from app.customTypes import Number, VehicleType
+from app.customTypes import VehicleType
 
 from . import socketio
 
@@ -146,22 +145,6 @@ def droneErrorCb(msg: Any) -> None:
         msg: The error message to send to the client
     """
     socketio.emit("drone_error", {"message": msg})
-
-
-class ConnectionDataType(TypedDict):
-    message: str
-    progress: Number
-    sub_message: NotRequired[str]
-
-
-def droneConnectStatusCb(msg: ConnectionDataType) -> None:
-    """
-    Send drone connect status updates to the socket
-
-    Args:
-        msg: The connect message to send to the client
-    """
-    socketio.emit("drone_connect_status", msg)
 
 
 def notConnectedError(action: Optional[str] = None) -> None:

--- a/radio/mypy.ini
+++ b/radio/mypy.ini
@@ -13,3 +13,5 @@ ignore_missing_imports = True
 ignore_missing_imports = True
 [mypy-docker.*]
 ignore_missing_imports = True
+[mypy-blinker.*]
+ignore_missing_imports = True


### PR DESCRIPTION
This is the basics of using signals, in its simplest form its easiest to just move what was the callbacks in utils to being handlers of their own route in `signals.py`

DroneConnectStatus is a full replacement of the old callback and so is the simplest example

DroneError shows two options, you can either directly send in each place you would have called the callback, or you can add a function to drone that essentially represents the old callback and you route all the calls through that.